### PR TITLE
Fixed platforms without ControlMessage support

### DIFF
--- a/mdns.go
+++ b/mdns.go
@@ -3,12 +3,13 @@ package dnssd
 import (
 	"context"
 	"fmt"
+	"net"
+	"runtime"
+
 	"github.com/brutella/dnssd/log"
 	"github.com/miekg/dns"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
-	"net"
-	"runtime"
 )
 
 var (
@@ -168,9 +169,12 @@ func (c *mdnsConn) readInto(ctx context.Context, ch chan *Request) {
 					continue
 				}
 
-				iface, err := net.InterfaceByIndex(cm.IfIndex)
-				if err != nil {
-					continue
+				var iface *net.Interface
+				if cm != nil {
+					iface, err = net.InterfaceByIndex(cm.IfIndex)
+					if err != nil {
+						continue
+					}
 				}
 
 				if n > 0 {
@@ -202,9 +206,12 @@ func (c *mdnsConn) readInto(ctx context.Context, ch chan *Request) {
 					continue
 				}
 
-				iface, err := net.InterfaceByIndex(cm.IfIndex)
-				if err != nil {
-					continue
+				var iface *net.Interface
+				if cm != nil {
+					iface, err = net.InterfaceByIndex(cm.IfIndex)
+					if err != nil {
+						continue
+					}
 				}
 
 				if n > 0 {


### PR DESCRIPTION
On certain platforms (Windows among others) `x/net/ipv{4,6}` currently sets the `ControlMessage` instance to `nil`. See [here](https://github.com/golang/net/blob/a04bdaca5b32abe1c069418fb7088ae607de5bd0/ipv4/payload.go#L13-L14) for the comment in the source code and [here](https://github.com/golang/go/issues/9252) for the matching Windows issue.

As far as I can see one could currently also just remove the entire `iface` code though, because I don't see the `(Request).iface` field being accessed anywhere in this package.