### PR TITLE
 Fix dnssd on Linux to respond to multicast DNS lookups.

### DIFF
--- a/browse.go
+++ b/browse.go
@@ -3,7 +3,6 @@ package dnssd
 import (
 	"context"
 	"github.com/miekg/dns"
-	"net"
 )
 
 type AddServiceFunc func(Service)
@@ -19,12 +18,6 @@ func LookupType(ctx context.Context, service string, add AddServiceFunc, rmv Rmv
 	}
 
 	defer conn.close()
-
-	ifaces, _ := net.Interfaces()
-	for _, ifi := range ifaces {
-		conn.ipv4.JoinGroup(&ifi, &net.UDPAddr{IP: IPv4LinkLocalMulticast})
-		conn.ipv6.JoinGroup(&ifi, &net.UDPAddr{IP: IPv6LinkLocalMulticast})
-	}
 
 	m := new(dns.Msg)
 	m.Question = []dns.Question{

--- a/mdns.go
+++ b/mdns.go
@@ -108,6 +108,14 @@ func newMDNSConn() (*mdnsConn, error) {
 			// Don't send us our own messages back
 			connIPv4.SetMulticastLoopback(false)
 		}
+
+		for _, iface := range multicastInterfaces() {
+			if err := connIPv4.JoinGroup(&iface, &net.UDPAddr{IP: IPv4LinkLocalMulticast}); err != nil {
+				log.Debug.Printf("Failed joining IPv4 %v: %v", iface.Name, err)
+			} else {
+				log.Debug.Printf("Joined IPv4 %v", iface.Name)
+			}
+		}
 	}
 
 	if conn, err := net.ListenUDP("udp6", AddrIPv6LinkLocalMulticast); err != nil {
@@ -119,6 +127,14 @@ func newMDNSConn() (*mdnsConn, error) {
 		if runtime.GOOS == "linux" {
 			// Don't send us our own messages back
 			connIPv6.SetMulticastLoopback(false)
+		}
+
+		for _, iface := range multicastInterfaces() {
+			if err := connIPv6.JoinGroup(&iface, &net.UDPAddr{IP: IPv6LinkLocalMulticast}); err != nil {
+				log.Debug.Printf("Failed joining IPv6 %v: %v", iface.Name, err)
+			} else {
+				log.Debug.Printf("Joined IPv6 %v", iface.Name)
+			}
 		}
 	}
 

--- a/responder_debug.go
+++ b/responder_debug.go
@@ -2,18 +2,12 @@ package dnssd
 
 import (
 	"context"
-	"net"
 )
 
 type ReadFunc func(*Request)
 
 func (r *responder) Debug(ctx context.Context, fn ReadFunc) {
 	conn := r.conn.(*mdnsConn)
-	ifaces, _ := net.Interfaces()
-	for _, ifi := range ifaces {
-		conn.ipv4.JoinGroup(&ifi, &net.UDPAddr{IP: IPv4LinkLocalMulticast})
-		conn.ipv6.JoinGroup(&ifi, &net.UDPAddr{IP: IPv6LinkLocalMulticast})
-	}
 
 	readCtx, readCancel := context.WithCancel(ctx)
 	defer readCancel()


### PR DESCRIPTION
dnssd was not joining the multicast DNS IPs 224.0.0.251 / [ff02::fb]

If an interface had not otherwise joined the multicast IPs, lookup packets were not being seen.

I believe on macOS it was working despite this because interfaces have typically already joined 224.0.0.251.

On Linux, not seeing the lookups was causing the record to disappear after the expiration of the SRV announcement.  Registered HomeKit devices would then be reported as "not responding".

Fixes #4.