### PR TITLE
The list of key/value will always be sorted by the key name

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/miekg/dns"
 	"net"
+	"sort"
 	"reflect"
 )
 
@@ -48,8 +49,15 @@ func SRV(srv Service) *dns.SRV {
 
 func TXT(srv Service) *dns.TXT {
 	txts := []string{}
-	for key, value := range srv.Text {
-		txts = append(txts, fmt.Sprintf("%s=%s", key, value))
+
+	var keys []string
+
+	for key, _ := range srv.Text {
+		keys = append(keys , key)
+	}
+	sort.Strings(keys)
+	for _ , k := range keys {
+		txts = append(txts, fmt.Sprintf("%s=%s", k, srv.Text[k]))
 	}
 
 	return &dns.TXT{

--- a/probe_test.go
+++ b/probe_test.go
@@ -8,13 +8,7 @@ import (
 	"time"
 )
 
-var testIface = &net.Interface{
-	Index:        0,
-	MTU:          0,
-	Name:         "lo0",
-	HardwareAddr: []byte{},
-	Flags:        net.FlagUp,
-}
+var testIface *net.Interface
 
 var testAddr = net.UDPAddr{
 	IP:   net.IP{},
@@ -81,6 +75,14 @@ func (c *testConn) start(ctx context.Context) {
 // service instance name and host name.Once the first services
 // is announced, the probing for the second service should give
 func TestProbing(t *testing.T) {
+	testIface,_ = net.InterfaceByName("lo0")
+	if testIface == nil {
+	   testIface,_ = net.InterfaceByName("lo")
+	}
+	if testIface == nil {
+		t.Fatal("can not find the local interface")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
in dns.go https://github.com/brutella/dnssd/blob/61d1bc6e53ace5b3d9ecb46ffd0b3158c00ae9d0/dns.go#L190 , the result of remove is not deterministic for TXT rr 
 
When we build the array Txt , we fill up by sorting by keys .
 