### PR TITLE
TXT records: fix parsing records with whitespace (e.g. ty=)

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,10 +1,11 @@
 package dnssd
 
 import (
-	"github.com/miekg/dns"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/miekg/dns"
 )
 
 type Cache struct {
@@ -94,21 +95,18 @@ loop:
 			if entry, ok := c.services[rr.Hdr.Name]; ok {
 				text := make(map[string]string)
 				for _, txt := range rr.Txt {
-					var pairs = strings.Split(txt, " ")
-					for _, pair := range pairs {
-						elems := strings.SplitN(pair, "=", 2)
-						if len(elems) == 2 {
-							key := elems[0]
-							value := elems[1]
+					elems := strings.SplitN(txt, "=", 2)
+					if len(elems) == 2 {
+						key := elems[0]
+						value := elems[1]
 
-							// Don't override existing keys
-							// TODO make txt records case insensitive
-							if _, ok := text[key]; !ok {
-								text[key] = value
-							}
-
+						// Don't override existing keys
+						// TODO make txt records case insensitive
+						if _, ok := text[key]; !ok {
 							text[key] = value
 						}
+
+						text[key] = value
 					}
 				}
 


### PR DESCRIPTION
My printer sets `ty=Brother MFC-L2750DW series`, which was previously cut off:

```https://github.com/stapelberg/dnssd
2020/07/18 17:14:40 DNSSD service discovered: {Brother\ MFC-L2750DW\ series
_uscan._tcp local BRNaaaaaaaaaaaa map[cs:binary,grayscale,color duplex:T
is:adf,platen note: pdl:application/pdf,image/jpeg rs:eSCL txtvers:1 ty:Brother
vers:2.63] 1h15m0s 80 [10.0.0.230]
```

But with this change, the record is parsed correctly:

```
2020/07/18 17:22:58 DNSSD service discovered: {Brother\ MFC-L2750DW\ series
_uscan._tcp local BRNaaaaaaaaaaaa map[cs:binary,grayscale,color duplex:T
is:adf,platen note: pdl:application/pdf,image/jpeg rs:eSCL txtvers:1 ty:Brother
MFC-L2750DW series vers:2.63] 1h15m0s 80 [10.0.0.230]
```

The format is described in more detail in RFC 6763 section 6:
https://tools.ietf.org/html/rfc6763#section-6

Notably, there is no whitespace-based framing specified, so I think the previous
code was just a mistake or misunderstanding.