### PR TITLE
(#23) remove default listening responder

### DIFF
--- a/responder.go
+++ b/responder.go
@@ -43,8 +43,6 @@ type responder struct {
 	upIfaces  []string
 }
 
-var DefaultResponder, _ = NewResponder()
-
 func NewResponder() (Responder, error) {
 	conn, err := newMDNSConn()
 	if err != nil {


### PR DESCRIPTION
Any program that uses this, or any code that depends on it, will by
default and without any way to opt out open port 5353 and do some
mdns communications over it.

I don't think this is useful since any real use will create a dedicated
responder.

I also cannot find this default responder used in any code anywhere

Signed-off-by: R.I.Pienaar <rip@devco.net>