### PR TITLE
Add host and port to BrowseEntry.

### DIFF
--- a/browse.go
+++ b/browse.go
@@ -12,6 +12,7 @@ import (
 
 type BrowseEntry struct {
 	IPs       []net.IP
+	Host      string
 	Port      int
 	IfaceName string
 	Name      string
@@ -89,6 +90,7 @@ func lookupType(ctx context.Context, service string, conn MDNSConn, add AddFunc,
 					if !found {
 						e := BrowseEntry{
 							IPs:       ips,
+							Host:      srv.Host,
 							Port:      srv.Port,
 							IfaceName: ifaceName,
 							Name:      srv.Name,

--- a/browse.go
+++ b/browse.go
@@ -12,6 +12,7 @@ import (
 
 type BrowseEntry struct {
 	IPs       []net.IP
+	Port      int
 	IfaceName string
 	Name      string
 	Type      string
@@ -88,6 +89,7 @@ func lookupType(ctx context.Context, service string, conn MDNSConn, add AddFunc,
 					if !found {
 						e := BrowseEntry{
 							IPs:       ips,
+							Port:      srv.Port,
 							IfaceName: ifaceName,
 							Name:      srv.Name,
 							Type:      srv.Type,


### PR DESCRIPTION
This PR adds the service's host name and port number to `BrowserEntry` to allow them to be consumed by callers of `LookupType()`.

This PR fixes #29, and also encompasses the changes from @xpol's PR #30.