### PR TITLE
Check for nil interfaces on various functions

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -113,6 +113,10 @@ func NSEC(rr dns.RR, srv Service, iface *net.Interface) *dns.NSEC {
 }
 
 func A(srv Service, iface *net.Interface) []*dns.A {
+	if iface == nil {
+		return []*dns.A{}
+	}
+
 	ips := srv.IPsAtInterface(iface)
 
 	var as []*dns.A
@@ -135,6 +139,10 @@ func A(srv Service, iface *net.Interface) []*dns.A {
 }
 
 func AAAA(srv Service, iface *net.Interface) []*dns.AAAA {
+	if iface == nil {
+		return []*dns.AAAA{}
+	}
+
 	ips := srv.IPsAtInterface(iface)
 
 	var aaaas []*dns.AAAA

--- a/service.go
+++ b/service.go
@@ -147,6 +147,10 @@ func (s *Service) Interfaces() []*net.Interface {
 
 // IPsAtInterface returns the ip address at a specific interface.
 func (s *Service) IPsAtInterface(iface *net.Interface) []net.IP {
+	if iface == nil {
+		return []net.IP{}
+	}
+
 	if ips, ok := s.ifaceIPs[iface.Name]; ok {
 		return ips
 	}


### PR DESCRIPTION
This fixes #34 by ensuring that nil interfaces don't cause panics if supplied.