### PR TITLE
Remove `return` statements after an infinite loop

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -181,8 +181,6 @@ func probe(ctx context.Context, conn MDNSConn, service Service) (conflict probeC
 			queryTime = time.After(delay)
 		}
 	}
-
-	return probeConflict{}, nil
 }
 
 func probeQuery(service Service, iface *net.Interface) *Query {

--- a/resolve.go
+++ b/resolve.go
@@ -61,6 +61,4 @@ func lookupInstance(ctx context.Context, instance string, conn MDNSConn) (srv Se
 			return
 		}
 	}
-
-	return
 }


### PR DESCRIPTION
`return` statements after an infinite loop are unreachable, thus redundant.