### PR TITLE
Extend Request interfaces for relay

### DIFF
--- a/mdns.go
+++ b/mdns.go
@@ -63,6 +63,14 @@ func (r Request) String() string {
 	return fmt.Sprintf("%s@%s\n%v", r.from.IP, r.IfaceName(), r.msg)
 }
 
+func (r Request) Raw() *dns.Msg {
+	return r.msg
+}
+
+func (r Request) From() *net.UDPAddr {
+	return r.from
+}
+
 // IfaceName returns the name of the network interface where the request was received.
 // If the network interface is unknown, the string "?" is returned.
 func (r Request) IfaceName() string {


### PR DESCRIPTION
Add functions to return the raw dns msg as well as the origin. This are useful when building a dns-sd relay that can also use dnssd debug features. (see my fork:  https://github.com/decent-e/dnssd in cmd/relay for the relay tool which I'm happy to contribute as well if you think its useful)

Signed-off-by: Eric Van Hensbergen <ericvh@gmail.com>