### PR TITLE
feat(probe): set write deadline on outgoing connection

### DIFF
--- a/mdns.go
+++ b/mdns.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/brutella/dnssd/log"
 	"github.com/miekg/dns"
@@ -354,6 +355,7 @@ func (c *mdnsConn) writeMsgTo(m *dns.Msg, iface *net.Interface, addr *net.UDPAdd
 					IfIndex: iface.Index,
 				}
 			}
+			c.ipv4.PacketConn.SetWriteDeadline(time.Now().Add(time.Second))
 			if _, err = c.ipv4.WriteTo(out, ctrl, addr); err != nil {
 				return err
 			}
@@ -368,6 +370,7 @@ func (c *mdnsConn) writeMsgTo(m *dns.Msg, iface *net.Interface, addr *net.UDPAdd
 					IfIndex: iface.Index,
 				}
 			}
+			c.ipv6.PacketConn.SetWriteDeadline(time.Now().Add(time.Second))
 			if _, err = c.ipv6.WriteTo(out, ctrl, addr); err != nil {
 				return err
 			}

--- a/probe.go
+++ b/probe.go
@@ -170,7 +170,7 @@ func probe(ctx context.Context, conn MDNSConn, service Service) (conflict probeC
 
 			queriesCount++
 			for _, q := range queries {
-				log.Debug.Println("Sending probe", q.msg)
+				log.Debug.Println("Sending probe", q.iface.Name, q.msg)
 				if err := conn.SendQuery(q); err != nil {
 					log.Debug.Println("Sending probe err:", err)
 				}


### PR DESCRIPTION
This adds a write deadline to the outgoing connections. Also logs the interface name on debug logging which really helped me debugging the issue described in https://github.com/brutella/hap/issues/34.

After this is merged, the package needs a new release tagged so I can PR a dependency update to hap.