### PR TITLE
Prevent `dnssd` from answering responses received

### DIFF
--- a/mdns.go
+++ b/mdns.go
@@ -274,7 +274,7 @@ func (c *mdnsConn) readInto(ctx context.Context, ch chan *Request) {
 
 				if n > 0 {
 					m := new(dns.Msg)
-					if err := m.Unpack(buf); err == nil && !shouldIgnore(m) {
+					if err := m.Unpack(buf); err == nil && !shouldIgnore(m) && !m.Response {
 						ch <- &Request{m, udpAddr, iface}
 					}
 				}
@@ -319,7 +319,7 @@ func (c *mdnsConn) readInto(ctx context.Context, ch chan *Request) {
 
 				if n > 0 {
 					m := new(dns.Msg)
-					if err := m.Unpack(buf); err == nil && !shouldIgnore(m) {
+					if err := m.Unpack(buf); err == nil && !shouldIgnore(m) && !m.Response {
 						ch <- &Request{m, udpAddr, iface}
 					}
 				}


### PR DESCRIPTION
`dnssd` currently answers any DNS packet that has non-empty questions
field. This might easily result in double-answering responses from non-compliant
responders that are sending responses with the questions section copied
from the query packet.

This PR explicitly filters out any packets that have `Response` bit set
from being processed as a part of request handling and also updates the
comments to make things more consistent.

Note that there is still an issue with concurrent use of resolver and
responder -- if both are in use and a resolver sends a request, it might
be received by a resolver, which will silently ignore it. This will need
bigger code changes.

Signed-off-by: Milan Plzik <milan.plzik@gmail.com>
