### PR TITLE
Implement legacy unicast response [RFC6762, 6.7]

### DIFF
--- a/mdns.go
+++ b/mdns.go
@@ -132,15 +132,8 @@ func (c *mdnsConn) SendQuery(q *Query) error {
 }
 
 // SendResponse sends a response.
-// The message is:
-// 1. sent as legacy unicast, if destination port is not 5353,
-// 2. sent as unicast, if the receiver address is specified in the response,
-// Otherwise the message is sent multicast.
+// The message is sent as unicast, if an receiver address is specified in the response.
 func (c *mdnsConn) SendResponse(resp *Response) error {
-	if isLegacyUnicastSource(resp.addr) {
-		return c.sendResponseTo(resp.msg, resp.iface, resp.addr)
-	}
-
 	if resp.addr != nil {
 		return c.sendResponseTo(resp.msg, resp.iface, resp.addr)
 	}


### PR DESCRIPTION
Section 6.7 specifies that for requests not coming from port 5353, the
responder must answer with responses akin to traditional DNS ones,
without any sanitization, removed questions or cache flush bit. This
behavior is used fairly often, e.g. Chrome browser on Android devices
uses this to resolve domain names.

This PR tries to track down all the necessary bits to make the legacy
unicast responses look like regular unicast DNS answers (and testing
with an Android device, it seems to have done the trick).

Signed-off-by: Milan Plzik <milan.plzik@gmail.com>
