### PR TITLE
fix: match DNS question with unescaped service name

### DIFF
--- a/resolve_test.go
+++ b/resolve_test.go
@@ -1,0 +1,75 @@
+package dnssd
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestRegisterServiceWithSpecialName(t *testing.T) {
+	cfg := Config{
+		Host:   "Computer",
+		Name:   "Test With Spaces",
+		Type:   "_asdf._tcp",
+		Domain: "local",
+		Port:   12345,
+		Ifaces: []string{"lo0"},
+	}
+	sv, err := NewService(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sv.ifaceIPs = map[string][]net.IP{
+		"lo0": []net.IP{net.IP{192, 168, 0, 123}},
+	}
+
+	conn := newTestConn()
+	otherConn := newTestConn()
+	conn.in = otherConn.out
+	conn.out = otherConn.in
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Run("resolver", func(t *testing.T) {
+		t.Parallel()
+
+		lookupCtx, lookupCancel := context.WithTimeout(ctx, 5*time.Second)
+
+		defer lookupCancel()
+		defer cancel()
+
+		srv, err := lookupInstance(lookupCtx, "Test With Spaces._asdf._tcp.local.", otherConn)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if is, want := srv.Name, "Test With Spaces"; is != want {
+			t.Fatalf("%v != %v", is, want)
+		}
+
+		if is, want := srv.Type, "_asdf._tcp"; is != want {
+			t.Fatalf("%v != %v", is, want)
+		}
+
+		if is, want := srv.Host, "Computer"; is != want {
+			t.Fatalf("%v != %v", is, want)
+		}
+
+		ips := srv.IPsAtInterface(&net.Interface{Name: "lo0"})
+		if is, want := len(ips), 1; is != want {
+			t.Fatalf("%v != %v", is, want)
+		}
+
+		if is, want := ips[0].String(), "192.168.0.123"; is != want {
+			t.Fatalf("%v != %v", is, want)
+		}
+	})
+
+	t.Run("responder", func(t *testing.T) {
+		t.Parallel()
+
+		r := newResponder(conn)
+		r.addManaged(sv) // don't probe
+		r.Respond(ctx)
+	})
+}

--- a/responder.go
+++ b/responder.go
@@ -409,7 +409,7 @@ func (r *responder) handleQuestion(q dns.Question, req *Request, srv Service) *d
 		log.Debug.Println("Shared record response wait", delay)
 		time.Sleep(delay)
 
-	case strings.ToLower(srv.EscapedServiceInstanceName()):
+	case strings.ToLower(srv.ServiceInstanceName()):
 		resp.Answer = []dns.RR{SRV(srv), TXT(srv), PTR(srv)}
 
 		var extra []dns.RR


### PR DESCRIPTION
Closes #50 

@brutella the test that I added passes for v1.2.11 and fails for v1.2.12 and v1.2.13. I identified the issue to the question/response logic as expected. Either the question should have an escaped name, or the question handler should match to the unescaped service name. I thought that it should be the latter, but please review.

Note: the test that I added is a copy of the test `TestRegisterServiceWithExplicitIP` with changed service name. No further thought went into that, so feel free to simplify the test.