### PR TITLE
Sets TTL for IP messages to 255

### DIFF
--- a/mdns.go
+++ b/mdns.go
@@ -180,6 +180,13 @@ func newMDNSConn(ifs ...string) (*mdnsConn, error) {
 		if err := connIPv4.SetMulticastLoopback(true); err != nil {
 			log.Debug.Println("IPv4 set multicast loopback:", err)
 		}
+		// Set TTL to 255 (rfc6762)
+		if err := connIPv4.SetTTL(255); err != nil {
+			log.Debug.Println("IPv4 set TTL:", err)
+		}
+		if err := connIPv4.SetMulticastTTL(255); err != nil {
+			log.Debug.Println("IPv4 set multicast TTL:", err)
+		}
 
 		for _, iface := range MulticastInterfaces(ifs...) {
 			if err := connIPv4.JoinGroup(iface, &net.UDPAddr{IP: IPv4LinkLocalMulticast}); err != nil {
@@ -201,7 +208,13 @@ func newMDNSConn(ifs ...string) (*mdnsConn, error) {
 		if err := connIPv6.SetMulticastLoopback(true); err != nil {
 			log.Debug.Println("IPv6 set multicast loopback:", err)
 		}
-
+		// Set TTL to 255 (rfc6762)
+		if err := connIPv6.SetHopLimit(255); err != nil {
+			log.Debug.Println("IPv4 set TTL:", err)
+		}
+		if err := connIPv6.SetMulticastHopLimit(255); err != nil {
+			log.Debug.Println("IPv4 set multicast TTL:", err)
+		}
 		for _, iface := range MulticastInterfaces(ifs...) {
 			if err := connIPv6.JoinGroup(iface, &net.UDPAddr{IP: IPv6LinkLocalMulticast}); err != nil {
 				log.Debug.Printf("Failed joining IPv6 %v: %v", iface.Name, err)


### PR DESCRIPTION
We are facing an issue where mDNS requests are not passing our managed switch due to the TTL is set to 1.

In rfc6762 is stated that IP TTL 255 should be used for mDNS IP multicast frames.

This PR sets the TTL to 255 for all outgoing UDP frames.