### PR TITLE
Fix conflict detection issue.

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -32,7 +32,9 @@ func (c *Cache) Services() []*Service {
 // UpdateFrom updates the cache from resource records in msg.
 // TODO consider the cache-flush bit to make records as to be deleted in one second
 func (c *Cache) UpdateFrom(req *Request) (adds []*Service, rmvs []*Service) {
-	answers := filterRecords(req, nil)
+	var answers []dns.RR
+	answers = append(answers, req.msg.Answer...)
+	answers = append(answers, req.msg.Extra...)
 	sort.Sort(byType(answers))
 
 	for _, answer := range answers {

--- a/probe.go
+++ b/probe.go
@@ -194,9 +194,6 @@ func probeQuery(service Service, iface *net.Interface) *Query {
 		Qclass: dns.ClassINET,
 	}
 
-	setQuestionUnicast(&instanceQ)
-	setQuestionUnicast(&hostQ)
-
 	msg.Question = []dns.Question{instanceQ, hostQ}
 
 	srv := SRV(service)


### PR DESCRIPTION
Setting the probeQuery to use unicast results in a failure to detect conflicts if no multicast query was performed beforehand.

### tested as below:
1. There is an instance of service "._scm._tcp" named "DATA BIFROST" on iPhone
2. Now，register the same instance on MacBook-Pro
3. Expected：instance named "DATA BIFROST (2)" registered

The test before the modification did not meet expectations：
> MacBook-Pro register % ./register
> Registering Service DATA BIFROST._scm._tcp.local. port 12345
> DATE: –––Wed Feb 26 2025–––
> 14:53:37.015 ...STARTING...
> INFO 2025/02/26 14:53:37 netlink_others.go:12: dnssd: unable to wait for link updates
> 14:53:38.864 Got a reply for service DATA BIFROST._scm._tcp.local.: Name now registered and active
> 
> MacBook-Pro ~ % dns-sd -Z _scm._tcp. local
> Browsing for _scm._tcp..local
> DATE: ---Wed 26 Feb 2025---
> 14:53:23.066 ...STARTING...
> 
> ; To direct clients to browse a different domain, substitute that domain in place of '@'
> lb._dns-sd._udp PTR @
> 
> ; In the list of services below, the SRV records will typically reference dot-local Multicast DNS names.
> ; When transferring this zone file data to your unicast DNS server, you'll need to replace those dot-local
> ; names with the correct fully-qualified (unicast) domain name of the target host offering the service.
> 
> _scm._tcp PTR DATA\032BIFROST._scm._tcp
> DATA\032BIFROST._scm._tcp SRV 0 0 1089 iPhone.local. ; Replace with unicast FQDN of target host
> DATA\032BIFROST._scm._tcp TXT "url=https://192.168.0.21:1089/" "uuid=edf03d9e-6cb0-4732-a148-559ab1023080"
> 
> _scm._tcp PTR DATA\032BIFROST._scm._tcp
> DATA\032BIFROST._scm._tcp SRV 0 0 12345 MacBook-Pro.local. ; Replace with unicast FQDN of target host
> DATA\032BIFROST._scm._tcp TXT ""

The test after the modification meet expectations:

> MacBook-Pro register % ./register
> Registering Service DATA BIFROST._scm._tcp.local. port 12345
> DATE: –––Wed Feb 26 2025–––
> 14:57:19.350 ...STARTING...
> INFO 2025/02/26 14:57:19 netlink_others.go:12: dnssd: unable to wait for link updates
> 14:57:23.755 Got a reply for service DATA BIFROST (2)._scm._tcp.local.: Name now registered and active
> 
> MacBook-Pro ~ % dns-sd -Z _scm._tcp. local
> Browsing for _scm._tcp..local
> DATE: ---Wed 26 Feb 2025---
> 14:57:13.556 ...STARTING...
> 
> ; To direct clients to browse a different domain, substitute that domain in place of '@'
> lb._dns-sd._udp PTR @
> 
> ; In the list of services below, the SRV records will typically reference dot-local Multicast DNS names.
> ; When transferring this zone file data to your unicast DNS server, you'll need to replace those dot-local
> ; names with the correct fully-qualified (unicast) domain name of the target host offering the service.
> 
> _scm._tcp PTR DATA\032BIFROST._scm._tcp
> DATA\032BIFROST._scm._tcp SRV 0 0 1089 iPhone.local. ; Replace with unicast FQDN of target host
> DATA\032BIFROST._scm._tcp TXT ""
> 
> _scm._tcp PTR DATA\032BIFROST\032(2)._scm._tcp
> DATA\032BIFROST\032(2)._scm._tcp SRV 0 0 12345 MacBook-Pro.local. ; Replace with unicast FQDN of target host
> DATA\032BIFROST\032(2)._scm._tcp TXT ""
> 