### PR TITLE
cmd: add -Txt arg for the 'register' command

### DIFF
--- a/cmd/dnssd/dnssd.go
+++ b/cmd/dnssd/dnssd.go
@@ -2,6 +2,8 @@
 package main
 
 import (
+	"errors"
+
 	"github.com/brutella/dnssd"
 	"github.com/brutella/dnssd/log"
 
@@ -16,7 +18,26 @@ import (
 	"time"
 )
 
-type mapArgs map[string]string
+type recordSet struct {
+	records map[string]string
+}
+
+func newRecordSet() recordSet {
+	return recordSet{records: make(map[string]string)}
+}
+
+func (s recordSet) String() string {
+	return fmt.Sprint(s.records)
+}
+
+func (r recordSet) Set(txt string) error {
+	key, value, ok := strings.Cut(txt, "=")
+	if !ok {
+		return errors.New(`value must be of the form "key=value"`)
+	}
+	r.records[key] = value
+	return nil
+}
 
 var nameFlag = flag.String("Name", "", "Service Name")
 var typeFlag = flag.String("Type", "", "Service type")
@@ -27,28 +48,12 @@ var portFlag = flag.Int("Port", 0, "")
 var interfaceFlag = flag.String("Interface", "", "")
 var timeFormat = "15:04:05.000"
 var verboseFlag = flag.Bool("Verbose", false, "Verbose logging")
-var txtRecords = mapArgs{}
+var txtRecords = newRecordSet()
 
 // Name of the invoked executable.
 var name = filepath.Base(os.Args[0])
 
 // Handle multiple args for TXT records
-func (s *mapArgs) String() string {
-	return fmt.Sprint(*s)
-}
-
-func (s *mapArgs) Set(value string) error {
-	key, value, ok := strings.Cut(value, "=")
-	if ok {
-		// key and value are set
-		(*s)[key] = value
-		return nil
-	}
-
-	// no "=" in s
-	return fmt.Errorf("value must of the form 'key=value'")
-}
-
 func registerTxtFlag() {
 	flag.Var(&txtRecords, "Txt", "can be used multiple times")
 }
@@ -133,7 +138,7 @@ func register(instance string) {
 			Ifaces: parseInterfaceFlag(),
 			IPs:    ips,
 			Host:   *hostFlag,
-			Text:   txtRecords,
+			Text:   txtRecords.records,
 		}
 		srv, err := dnssd.NewService(cfg)
 		if err != nil {

--- a/cmd/dnssd/dnssd.go
+++ b/cmd/dnssd/dnssd.go
@@ -16,6 +16,8 @@ import (
 	"time"
 )
 
+type mapArgs map[string]string
+
 var nameFlag = flag.String("Name", "", "Service Name")
 var typeFlag = flag.String("Type", "", "Service type")
 var domainFlag = flag.String("Domain", "local", "Service Domain")
@@ -25,14 +27,36 @@ var portFlag = flag.Int("Port", 0, "")
 var interfaceFlag = flag.String("Interface", "", "")
 var timeFormat = "15:04:05.000"
 var verboseFlag = flag.Bool("Verbose", false, "Verbose logging")
+var txtRecords = mapArgs{}
 
 // Name of the invoked executable.
 var name = filepath.Base(os.Args[0])
 
+// Handle multiple args for TXT records
+func (s *mapArgs) String() string {
+	return fmt.Sprint(*s)
+}
+
+func (s *mapArgs) Set(value string) error {
+	key, value, ok := strings.Cut(value, "=")
+	if ok {
+		// key and value are set
+		(*s)[key] = value
+		return nil
+	}
+
+	// no "=" in s
+	return fmt.Errorf("value must of the form 'key=value'")
+}
+
+func registerTxtFlag() {
+	flag.Var(&txtRecords, "Txt", "can be used multiple times")
+}
+
 func printUsage() {
 	log.Info.Println("A DNS-SD utilty to register, browse and resolve Bonjour services.\n\n" +
 		"Usage:\n" +
-		"  " + name + " register -Name <string> -Type <string> -Port <int> [-Domain <string> -Interface <string[,string]> -Host <string> -IP <string>]\n" +
+		"  " + name + " register -Name <string> -Type <string> -Port <int> [-Domain <string> -Interface <string[,string]> -Txt <string=string>... -Host <string> -IP <string>]\n" +
 		"  " + name + " browse                  -Type <string>             [-Domain <string> -Interface <string[,string]>]\n" +
 		"  " + name + " resolve  -Name <string> -Type <string>             [-Domain <string> -Interface <string[,string]>]\n")
 }
@@ -109,6 +133,7 @@ func register(instance string) {
 			Ifaces: parseInterfaceFlag(),
 			IPs:    ips,
 			Host:   *hostFlag,
+			Text:   txtRecords,
 		}
 		srv, err := dnssd.NewService(cfg)
 		if err != nil {
@@ -196,6 +221,8 @@ func main() {
 		printUsage()
 		return
 	}
+
+	registerTxtFlag()
 
 	// The first argument is the command.
 	cmd := args[0]


### PR DESCRIPTION
# Description

```dnssd register``` command is a wonderful tool for announcing a new service over a network. However it is currently impossible to specify the TXT record of the DNS entry with the current implementation.

This tiny pull request expose this feature on the command line.

Thank you for maintaining this wonderful project @brutella !